### PR TITLE
docs: AC再監査レポートを追加（Issue #5）

### DIFF
--- a/docs/ac_audit_2026-02-15.md
+++ b/docs/ac_audit_2026-02-15.md
@@ -1,0 +1,65 @@
+# AC Audit Report (2026-02-15)
+
+Issue: `#5`  
+Branch: `feat/ac-audit-rerun`
+
+## Result
+
+| AC | Status |
+|---|---|
+| A 設定 | Pass |
+| B 取得 | Pass |
+| C フィルタ | Pass |
+| D 永続化 | Pass |
+| E メール | Pass |
+| F Actions | Pass |
+| G 運用 | Pass |
+| H セキュリティ | Pass |
+
+## Evidence (Code References)
+
+- A 設定
+  - `src/bid_rss_mailer/config.py:102` id重複検知
+  - `src/bid_rss_mailer/config.py:116` 正規化URL重複検知
+  - `src/bid_rss_mailer/main.py:135` 失敗通知
+- B 取得
+  - `src/bid_rss_mailer/fetcher.py:74` `feedparser` によるRSS/Atom/RDF処理
+  - `src/bid_rss_mailer/fetcher.py:83` title/link必須
+  - `src/bid_rss_mailer/fetcher.py:87` date欠損fallback
+  - `src/bid_rss_mailer/main.py:135` 全落ち通知条件
+- C フィルタ
+  - `src/bid_rss_mailer/scorer.py:35` required 2語以上
+  - `src/bid_rss_mailer/scorer.py:49` boost加点
+  - `src/bid_rss_mailer/scorer.py:41` exclude原則除外
+  - `src/bid_rss_mailer/scorer.py:8` 決定的sort
+  - `src/bid_rss_mailer/pipeline.py:67` TopN
+  - `src/bid_rss_mailer/pipeline.py:60` 重複URL同報抑止
+- D 永続化
+  - `src/bid_rss_mailer/storage.py:12` `items`/`deliveries`
+  - `src/bid_rss_mailer/storage.py:72` URL hash再送防止
+  - `src/bid_rss_mailer/storage.py:51` 30日保持
+  - `src/bid_rss_mailer/main.py:190` DB失敗時通知経路
+- E メール
+  - `src/bid_rss_mailer/main.py:35` SMTP env検証
+  - `src/bid_rss_mailer/pipeline.py:123` 1実行1通
+  - `src/bid_rss_mailer/mailer.py:32` 行フォーマット
+  - `src/bid_rss_mailer/mailer.py:98` 軽リトライ
+- F Actions
+  - `.github/workflows/daily-mail.yml:8` cron UTC22:00
+  - `.github/workflows/daily-mail.yml:9` workflow_dispatch
+  - `.github/workflows/daily-mail.yml:83` DB_PATH一貫
+- G 運用
+  - `README.md:80` コピペ手順
+  - `.env.example:1` 環境変数テンプレート
+  - `README.md:178` 取得不可RSS記録
+- H セキュリティ
+  - `.github/workflows/daily-mail.yml:75` secrets参照
+  - `README.md:181` 出典方針（リンク参照/本文保存なし）
+
+## Local Runtime Evidence
+
+- `pytest -q` -> `14 passed`
+- `python -m bid_rss_mailer.main self-test --skip-smtp --db-path data/ac-rerun.db` -> `self-test: ok`
+- `python -m bid_rss_mailer.main run --dry-run --db-path data/ac-rerun.db` -> `fetched=167 selected=28 failures=0 digest_sent=False`
+- mock SMTP run -> `fetched=167 selected=28 failures=0 digest_sent=True`
+


### PR DESCRIPTION
## What\n- AC再監査の結果を docs/ac_audit_2026-02-15.md に追加\n- A-HのPass判定、根拠ファイル、ローカル/Actions Evidenceを記録\n\n## Why\n- Issue #5 の要求（Issue→採点→計画→検証→Evidence→PR）を再実行し、現行mainのMVP適合を明文化するため。\n\n## Evidence\n### Local\n- pytest -q -> 14 passed in 0.97s\n- self-test --skip-smtp -> self-test: ok\n- un --dry-run -> etched=167 selected=28 failures=0 digest_sent=False\n- mock SMTP run -> etched=167 selected=28 failures=0 digest_sent=True\n\n### GitHub Actions\n- CI success: https://github.com/yosukev2/bid-rss-mailer/actions/runs/22034261862\n  - 14 passed in 0.43s\n- Daily success: https://github.com/yosukev2/bid-rss-mailer/actions/runs/22034261876\n  - un complete ... fetched=167 selected=28 failures=0 digest_sent=True dry_run=False\n\n## Impact\n- 追加ファイル: docs/ac_audit_2026-02-15.md\n- 実装コード変更なし\n\n## DoD\n- [x] AC A-H採点の明文化\n- [x] 根拠ファイル/行の記録\n- [x] ローカル/Actions Evidence記録\n- [x] PR作成\n\nCloses #5