### PR TITLE
Issue5: rerun MVP AC audit with evidence

### DIFF
--- a/docs/ac_audit_2026-02-17.md
+++ b/docs/ac_audit_2026-02-17.md
@@ -198,6 +198,9 @@ export DB_PATH="${GITHUB_WORKSPACE}/data/app.db"
 
 ## Actions Evidence
 
-- `ci`: (push run URLを追記)
-- `daily-bid-rss-mail`: (push/workflow_dispatch run URLを追記)
-
+- `ci` (push): https://github.com/yosukev2/bid-rss-mailer/actions/runs/22102072439  
+  - `docs/evidence/issue5_actions_ci.log`  
+  - `pytest -q` -> `39 passed in 0.60s`
+- `daily-bid-rss-mail` (workflow_dispatch): https://github.com/yosukev2/bid-rss-mailer/actions/runs/22102167358  
+  - `docs/evidence/issue5_actions_daily_dispatch.log`  
+  - `run complete: ... dry_run=True` を確認


### PR DESCRIPTION
## What
- Re-ran MVP AC audit (A-H) against current `main` baseline and recorded Pass/Fail table.
- Added concrete evidence with file-path + near-line code excerpts for every AC item.
- Added rerun verification evidence (local + GitHub Actions) into a new audit report.
- Captured and linked runtime evidence logs for:
  - local `pytest`, `self-test`, `run --dry-run`, mock SMTP run
  - Actions `ci` and `daily-bid-rss-mail`

## Why
- Issue #5 requires a strict AC rerun with explicit evidence and minimal-fix policy.
- Current implementation already satisfies A-H; therefore no product-code change was needed, only audit/evidence materialization.

## Evidence
- Audit report: `docs/ac_audit_2026-02-17.md`
- Local logs:
  - `docs/evidence/issue5_local_pytest.log`
  - `docs/evidence/issue5_local_self_test.log`
  - `docs/evidence/issue5_local_run_dry.log`
  - `docs/evidence/issue5_local_run_mock_smtp.log`
- Actions logs:
  - `docs/evidence/issue5_actions_ci.log`
  - `docs/evidence/issue5_actions_daily_dispatch.log`
- Run URLs:
  - CI (push): https://github.com/yosukev2/bid-rss-mailer/actions/runs/22102072439
  - Daily (workflow_dispatch): https://github.com/yosukev2/bid-rss-mailer/actions/runs/22102167358

## Impact
- Documentation-only change.
- No behavior change to runtime pipeline, storage, delivery, workflows, or security handling.

## DoD
- [x] A-H Pass/Fail table completed.
- [x] File-path + line-adjacent excerpts attached per AC.
- [x] Fail item breakdown handled (no Fail).
- [x] Local verification evidence captured.
- [x] Actions verification evidence captured.
- [x] Commit split and PR created.

Closes #5